### PR TITLE
Fix incorrect partitioning on graphs with isolated nodes

### DIFF
--- a/lib/algorithms/node_partitioning/model/node_batch_model_builder.cpp
+++ b/lib/algorithms/node_partitioning/model/node_batch_model_builder.cpp
@@ -31,7 +31,7 @@ EdgeID insert_regular_local_edge_in_batch(
         std::cerr << "The graph file contains self-loops, which are not supported. "
                      "Please remove them from the file."
                   << '\n';
-        exit(0);
+        exit(1);
     }
     return partition_model::graph_ops::include_edge(all_edges, node, local_target,
                                                     non_ghost_multiplier * edge_weight);

--- a/lib/io/stream_reader.cpp
+++ b/lib/io/stream_reader.cpp
@@ -47,10 +47,11 @@ void open_binary_stream(io::stream::StreamCursor& cursor, const std::string& gra
 
 bool read_next_non_comment_line(std::ifstream& stream_in, std::string& line) {
     while (std::getline(stream_in, line)) {
-        if (line.empty()) {
-            continue;
-        }
-        if (line[0] == '%') {
+        // Only skip comment lines (starting with %).
+        // Do NOT skip empty lines — in METIS format, an empty line in the
+        // adjacency body represents an isolated node with no neighbors.
+        // Skipping empty lines shifts all subsequent node indices.
+        if (!line.empty() && line[0] == '%') {
             continue;
         }
         return true;

--- a/lib/partition/model/model_graph_ops.cpp
+++ b/lib/partition/model/model_graph_ops.cpp
@@ -27,7 +27,7 @@ EdgeID insert_regular_edge(Config& config,
         std::cerr << "The graph file contains self-loops, which are not supported. "
                      "Please remove them from the file."
                   << '\n';
-        exit(0);
+        exit(1);
     }
     if (target > node) {
         // Store each undirected edge once; symmetric edge is added in include_edge.


### PR DESCRIPTION
## Summary
- `read_next_non_comment_line()` in `stream_reader.cpp` skipped empty lines, but in METIS format an empty line represents an isolated node (no neighbors). This shifted all subsequent node indices, causing false self-loop detection and incorrect partitioning on any graph with isolated nodes.
- Fix: only skip `%` comment lines, not empty lines.
- Also changed `exit(0)` → `exit(1)` in self-loop error paths so failures are detectable by calling processes.

## Reproduction

Any METIS graph with isolated nodes triggers this. astro-ph (16,706 nodes, 660 isolated) consistently fails:

```
# Before fix:
$ ./heistream astro-ph.graph --k=2 --imbalance=3 --seed=0
The graph file contains self-loops, which are not supported. ...
$ echo $?
0

# After fix:
$ ./heistream astro-ph.graph --k=2 --imbalance=3 --seed=0
| Edge cut                     |                  10726 |
| Balance                      |               1.030049 |
```

Tested with k=2, k=4, k=8 — all produce valid partitions after the fix.

Fixes #3