### PR TITLE
Remove unused MPI dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,6 @@ if(COMPILER_SUPPORTS_FPERMISSIVE)
 endif()
 
 # check dependencies
-find_package(MPI REQUIRED)
 find_package(OpenMP)
 if(OpenMP_CXX_FOUND)
   message(STATUS "OpenMP support detected")

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Our experiments demonstrate that HeiStreamE produces the best solution quality (
 
 - C++17 compiler (e.g., `g++`/`clang++`)
 - CMake
-- MPI development package
 - OpenMP support in the compiler toolchain
 - Git (needed by CMake `FetchContent` dependencies)
 


### PR DESCRIPTION
## Summary
- Remove `find_package(MPI REQUIRED)` from `CMakeLists.txt` — no source file includes MPI headers or calls MPI functions
- Remove "MPI development package" from requirements in `README.md`

## Verification
Verified that the project configures, compiles, and links cleanly without MPI on a clean clone.